### PR TITLE
Remove redundant code

### DIFF
--- a/game.tsp
+++ b/game.tsp
@@ -115,9 +115,7 @@ block main do
             elif input_value { "G" "H" "I" } in do
                 2 -> row
             else
-                "unreachable\r\033[1A" print
-                input -> input_value
-                "\033[2K\033[1A\033[2K\n" print
+                "unreachable" print
                 break
             end
 


### PR DESCRIPTION
Not only is the code redundant, it also creates a bug where if you enter something unreachable on one turn, then on the next turn an actual move, it will just do nothing. Now this is fixed.